### PR TITLE
 Updated HSTS to support the preload flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Enables [Platform for Privacy Preferences Project](http://support.microsoft.com/
 * `options.maxAge` Number - Required. Number of seconds HSTS is in effect.
 * `options.includeSubDomains` Boolean - Optional. Applies HSTS to all subdomains of the host
 
-Enables [HTTP Strict Transport Security](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security) for the host domain.
+Enables [HTTP Strict Transport Security](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security) for the host domain. The preload flag is required for HSTS domain submissions to [Chrome's HSTS preload list](https://hstspreload.appspot.com)
 
 ### lusca.xssProtection(options)
 

--- a/lib/hsts.js
+++ b/lib/hsts.js
@@ -54,6 +54,7 @@ module.exports = function (options) {
   if (options.includeSubDomains) {
     value += '; includeSubDomains';
   }
+  value += (value && options.preload) ? '; preload' : '';
 
   return function* hsts(next) {
     this.set('Strict-Transport-Security', value);

--- a/test/hsts.js
+++ b/test/hsts.js
@@ -76,6 +76,21 @@ describe('HSTS', function () {
     .expect(200, done);
   });
 
+  it('header (maxAge; includeSubDomains; preload)', function (done) {
+    var config = { hsts: { maxAge: 31536000, includeSubDomains: true, preload: true } };
+    var app = mock(config);
+
+    app.get('/', function* () {
+      this.body = 'hello';
+    });
+
+    request(app.listen())
+    .get('/')
+    .expect('Strict-Transport-Security', 'max-age=' + config.hsts.maxAge + '; includeSubDomains; preload')
+    .expect('hello')
+    .expect(200, done);
+  });
+
   it('header (missing maxAge)', function () {
     assert.throws(function () {
       mock({ hsts: {} });


### PR DESCRIPTION
Hey, I've updated the koa-lusca-hsts implementation to support the preload flag. This flag is required for HSTS domain submissions to Chrome's preload list. The changes include new feature support, new test case, and updated docs. More information regarding preload is available below

https://hstspreload.appspot.com/